### PR TITLE
refactor: バージョニングの方法を変更

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -7,8 +7,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-build-num:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_NUM_OFFSET: 115
+    outputs:
+      build-num: ${{ steps.build-num.outputs.build-num }}
+
+    steps:
+      - id: build-num
+        run: echo build-num=$(($GITHUB_RUN_NUMBER + $BUILD_NUM_OFFSET)) >> $GITHUB_OUTPUT
+
   build-ios: # Build and deploy iOS app to App Store
     name: Build iOS
+    needs:
+      - get-build-num
     runs-on: macos-latest
 
     steps:
@@ -53,7 +66,7 @@ jobs:
         run: echo -n "${{ secrets.APPLE_GOOGLE_SERVICE_INFO_RELEASE_PLIST_BASE64 }}" | base64 -d > ios/GoogleService-Info-release.plist
 
       - name: Build IPA
-        run: flutter build ipa --export-options-plist ios/exportOptions.plist
+        run: flutter build ipa --build-number ${{ needs.get-build-num.outputs.build-num }} --export-options-plist ios/exportOptions.plist
 
       - name: Deploy to App Store
         run: |
@@ -63,6 +76,8 @@ jobs:
 
   build-android: # Build and deploy Android app to Google Play
     name: Build Android
+    needs:
+      - get-build-num
     runs-on: ubuntu-latest
 
     steps:
@@ -108,7 +123,7 @@ jobs:
           echo -n ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }} | base64 -d > android/app/src/release/google-services.json
 
       - name: Build App Bundle for Android
-        run: flutter build appbundle
+        run: flutter build appbundle --build-number ${{ needs.get-build-num.outputs.build-num }}
 
       - name: Import Service Account Key
         run: echo '${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY_BASE64 }}' | base64 -d > service_account_key.json

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -2,6 +2,8 @@ name: Build and Deploy Apps
 
 on:
   push:
+    branches:
+      - main
     tags:
       - v*.*.*
   workflow_dispatch:
@@ -151,7 +153,7 @@ jobs:
       - build-ios
       - build-android
     runs-on: ubuntu-latest
-    if: "!contains(github.ref, '-')"
+    if: "github.ref_name != '' && !contains(github.ref_name, '-')"
     permissions:
       contents: write
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.2.0+134
+version: 1.2.0
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
ビルド番号を`GITHUB_RUN_NUMBER`で管理するようにし、バージョンは`v1.2.0-beta.1`のようにする。