### PR TITLE
fix: アカウント変更関連のリンクハンドラーの実装改善

### DIFF
--- a/lib/auth/sign_in_handler.dart
+++ b/lib/auth/sign_in_handler.dart
@@ -204,6 +204,10 @@ class SignInHandler {
   }
 
   Future<SignInError?> completeSignIn(UserCredential userCred) async {
+    if (mode == SignInMode.reauthenticate) {
+      return null;
+    }
+
     try {
       SharedPrefs.use((prefs) {
         prefs.firestoreLastChanged = null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -244,11 +244,13 @@ class _ApplicationState extends State<Application> {
           case SignInPage.routeName:
             var args = settings.arguments as SignInPageArguments;
             return generatePageRoute<bool>(
-                (context) => SignInPage(
-                      initialCred: args.initialCred,
-                      mode: args.mode,
-                    ),
-                settings);
+              (context) => SignInPage(
+                initialCred: args.initialCred,
+                mode: args.mode,
+                continuePath: args.continuePath,
+              ),
+              settings,
+            );
           case EmailSignInPage.routeName:
             var args = settings.arguments as EmailSignInPageArguments;
             return generatePageRoute<SignInResult>(
@@ -289,21 +291,20 @@ class _ApplicationState extends State<Application> {
                 settings);
           case AccountEditPage.changeEmailRouteName:
             return generatePageRoute(
-                (context) => const AccountEditPage(EditingType.changeEmail),
+                (context) => AccountEditPage(EditingType.changeEmail,
+                    args: settings.arguments as AccountEditPageArguments?),
                 settings);
           case AccountEditPage.changePasswordRouteName:
             return generatePageRoute(
-                (context) => const AccountEditPage(EditingType.changePassword),
+                (context) => AccountEditPage(EditingType.changePassword),
                 settings);
           case AccountEditPage.changeDisplayNameRouteName:
             return generatePageRoute(
-                (context) =>
-                    const AccountEditPage(EditingType.changeDisplayName),
+                (context) => AccountEditPage(EditingType.changeDisplayName),
                 settings);
           case AccountEditPage.deleteRouteName:
             return generatePageRoute(
-                (context) => const AccountEditPage(EditingType.delete),
-                settings);
+                (context) => AccountEditPage(EditingType.delete), settings);
           default:
             return null;
         }

--- a/lib/pages/settings/account_edit_page.dart
+++ b/lib/pages/settings/account_edit_page.dart
@@ -6,7 +6,6 @@ import 'package:submon/utils/ui.dart';
 import 'package:submon/utils/utils.dart';
 
 import '../../main.dart';
-import '../../utils/dynamic_links.dart';
 
 class AccountEditPage extends StatefulWidget {
   AccountEditPage(this.type, {Key? key, AccountEditPageArguments? args})
@@ -131,8 +130,7 @@ class _AccountEditPageState extends State<AccountEditPage> {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text(
           "メールアドレスを変更します。\n\n"
-          "新しいメールアドレスを入力して「送信」をタップすると、新しいメールアドレスに確認URLが送信されます。このURLをタップすることで、メールアドレスの変更が完了します。\n"
-          "「送信」をタップするだけでは変更は完了しませんのでご注意ください。\n\n"
+          "変更後、元のメールアドレスに通知メールを送信します。このメール内のリンクを利用して、メールアドレスを元に戻すことも可能です。\n\n"
           "※メールは「submon.app」ドメインから送信されます。迷惑メールに振り分けられていないか確認してください。",
           style: Theme.of(context).textTheme.bodyLarge),
       const SizedBox(height: 16),
@@ -163,11 +161,11 @@ class _AccountEditPageState extends State<AccountEditPage> {
     });
 
     try {
-      await FirebaseAuth.instance.currentUser!.verifyBeforeUpdateEmail(
-          _form1Controller.text,
-          actionCodeSettings(getAppDomain("", withScheme: true)));
+      await FirebaseAuth.instance.currentUser!.updateEmail(
+        _form1Controller.text,
+      );
 
-      showSnackBar(context, "送信しました。ご確認ください。");
+      showSnackBar(context, "メールアドレスを変更しました。");
       Navigator.pop(context);
     } on FirebaseAuthException catch (e, stack) {
       switch (e.code) {

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -16,12 +16,18 @@ import 'package:submon/utils/utils.dart';
 import '../utils/dynamic_links.dart';
 
 class SignInPage extends StatefulWidget {
-  const SignInPage({Key? key, required this.initialCred, required this.mode}) : super(key: key);
+  const SignInPage(
+      {Key? key,
+      required this.initialCred,
+      required this.mode,
+      this.continuePath})
+      : super(key: key);
 
   static const routeName = "/sign-in";
 
   final UserCredential? initialCred;
   final SignInMode mode;
+  final String? continuePath;
 
   @override
   State<SignInPage> createState() => _SignInPageState();
@@ -30,8 +36,9 @@ class SignInPage extends StatefulWidget {
 class SignInPageArguments {
   final UserCredential? initialCred;
   final SignInMode mode;
+  final String? continuePath;
 
-  const SignInPageArguments(this.mode, [this.initialCred]);
+  const SignInPageArguments(this.mode, {this.initialCred, this.continuePath});
 }
 
 class _SignInPageState extends State<SignInPage> {
@@ -241,15 +248,15 @@ class _SignInPageState extends State<SignInPage> {
           showSimpleDialog(
             globalContext!,
             "追加認証",
-            "セキュリティのため、再度ログインする必要があります。送信されたメールにあるURLをタップし、ログインしてください。\n\n"
-                "その後、再度メールアドレス変更をお試しください。",
+            "セキュリティのため、再度ログインする必要があります。送信されたメールにあるURLをタップし、ログインしてください。",
             onOKPressed: () async {
               showLoadingModal(context);
               try {
                 await auth.sendSignInLinkToEmail(
                     email: currentUser.email!,
-                    actionCodeSettings:
-                        actionCodeSettings(getAppDomain("", withScheme: true)));
+                    actionCodeSettings: actionCodeSettings(getAppDomain(
+                        widget.continuePath ?? "",
+                        withScheme: true)));
                 if (mounted) showSnackBar(context, "送信しました");
               } catch (e, stack) {
                 showSnackBar(context, "エラーが発生しました");


### PR DESCRIPTION
- SignInPageにcontinueUrlを受けられるようにし、リンクタップ時にリンクの種類を判別できるように
- 再認証時に「ログアウトしてから操作してください」という旨のメッセージが出て、アカウント削除やメールアドレスの変更が出来なかった問題の修正
- メールアドレス変更時、リンクをタップするだけで処理が完了するように