### PR TITLE
refactor(core): T11 replace EventBus with Riverpod streams

### DIFF
--- a/lib/events.dart
+++ b/lib/events.dart
@@ -1,9 +1,0 @@
-import "package:event_bus/event_bus.dart";
-
-final eventBus = EventBus();
-
-class SwitchBottomNav {
-  String path;
-
-  SwitchBottomNav(this.path);
-}

--- a/lib/infrastructure/tab_switch_provider.dart
+++ b/lib/infrastructure/tab_switch_provider.dart
@@ -1,0 +1,36 @@
+import "dart:async";
+
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+part "tab_switch_provider.g.dart";
+
+/// A request to switch the bottom navigation to the tab identified by [path].
+///
+/// Emitted in response to deep links so the home page can select the matching
+/// bottom-nav tab once it is ready.
+class TabSwitchRequest {
+  const TabSwitchRequest(this.path);
+
+  final String path;
+}
+
+/// Holds the [StreamController] that carries [TabSwitchRequest]s.
+///
+/// Routes tab-switch requests through Riverpod instead of an out-of-band global
+/// singleton. [fire] publishes a request and the exposed stream is consumed
+/// (via `ref.listen`) by the home page.
+@Riverpod(keepAlive: true)
+class TabSwitch extends _$TabSwitch {
+  final _controller = StreamController<TabSwitchRequest>.broadcast();
+
+  @override
+  Stream<TabSwitchRequest> build() {
+    ref.onDispose(_controller.close);
+    return _controller.stream;
+  }
+
+  /// Publishes a request to switch to the tab identified by [path].
+  void fire(String path) {
+    _controller.add(TabSwitchRequest(path));
+  }
+}

--- a/lib/infrastructure/tab_switch_provider.g.dart
+++ b/lib/infrastructure/tab_switch_provider.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'tab_switch_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Holds the [StreamController] that carries [TabSwitchRequest]s.
+///
+/// Routes tab-switch requests through Riverpod instead of an out-of-band global
+/// singleton. [fire] publishes a request and the exposed stream is consumed
+/// (via `ref.listen`) by the home page.
+
+@ProviderFor(TabSwitch)
+final tabSwitchProvider = TabSwitchProvider._();
+
+/// Holds the [StreamController] that carries [TabSwitchRequest]s.
+///
+/// Routes tab-switch requests through Riverpod instead of an out-of-band global
+/// singleton. [fire] publishes a request and the exposed stream is consumed
+/// (via `ref.listen`) by the home page.
+final class TabSwitchProvider
+    extends $StreamNotifierProvider<TabSwitch, TabSwitchRequest> {
+  /// Holds the [StreamController] that carries [TabSwitchRequest]s.
+  ///
+  /// Routes tab-switch requests through Riverpod instead of an out-of-band global
+  /// singleton. [fire] publishes a request and the exposed stream is consumed
+  /// (via `ref.listen`) by the home page.
+  TabSwitchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'tabSwitchProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$tabSwitchHash();
+
+  @$internal
+  @override
+  TabSwitch create() => TabSwitch();
+}
+
+String _$tabSwitchHash() => r'd722c67fb53a6982ebaa05221d95be99b185117d';
+
+/// Holds the [StreamController] that carries [TabSwitchRequest]s.
+///
+/// Routes tab-switch requests through Riverpod instead of an out-of-band global
+/// singleton. [fire] publishes a request and the exposed stream is consumed
+/// (via `ref.listen`) by the home page.
+
+abstract class _$TabSwitch extends $StreamNotifier<TabSwitchRequest> {
+  Stream<TabSwitchRequest> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<TabSwitchRequest>, TabSwitchRequest>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<TabSwitchRequest>, TabSwitchRequest>,
+              AsyncValue<TabSwitchRequest>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,6 @@ import "package:package_info_plus/package_info_plus.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
 import "core/pref_key.dart";
-import "events.dart";
 import "features/auth/presentation/auth_action_notifier.dart";
 import "features/auth/presentation/auth_messages.dart";
 import "features/auth/presentation/email_link_auth_notifier.dart";
@@ -30,6 +29,7 @@ import "infrastructure/core_providers.dart";
 import "infrastructure/firebase_providers.dart";
 import "infrastructure/firestore_error_notifier.dart";
 import "infrastructure/pref_provider.dart";
+import "infrastructure/tab_switch_provider.dart";
 import "link_handler/link_handler.dart";
 import "pages/done_submissions_page.dart";
 import "pages/email_registration_page.dart";
@@ -147,7 +147,7 @@ class _ApplicationState extends ConsumerState<Application> {
     ref.listen(linkEventsProvider, (_, next) {
       if (next case AsyncData(:final value)) {
         handleLink(_navContext, ref, value.value, onSwitchTab: (tabName) {
-          eventBus.fire(SwitchBottomNav(tabName));
+          ref.read(tabSwitchProvider.notifier).fire(tabName);
         });
       }
     });

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -11,13 +11,13 @@ import "package:google_mobile_ads/google_mobile_ads.dart";
 import "../browser.dart";
 import "../components/digestive_edit_bottom_sheet.dart";
 import "../core/pref_key.dart";
-import "../events.dart";
 import "../fade_through_page_route.dart";
 import "../features/auth/use_cases/sign_out_use_case.dart";
 import "../features/digestive/models/isar_digestive.dart";
 import "../features/digestive/repositories/digestive_providers.dart";
 import "../infrastructure/core_providers.dart";
 import "../infrastructure/firebase_providers.dart";
+import "../infrastructure/tab_switch_provider.dart";
 import "../providers/data_sync_service.dart";
 import "../src/pigeons.g.dart";
 import "../ui_components/hidable_progress_indicator.dart";
@@ -43,7 +43,6 @@ class HomePage extends ConsumerStatefulWidget {
 
 class HomePageState extends ConsumerState<HomePage> {
   final _navigatorKey = GlobalKey<NavigatorState>();
-  StreamSubscription? switchBottomNavListener;
 
   final _scrollControllers = {
     for (final path in ["home", "digestive", "more"])
@@ -130,27 +129,6 @@ class HomePageState extends ConsumerState<HomePage> {
       }
     });
 
-    switchBottomNavListener = eventBus.on<SwitchBottomNav>().listen((event) {
-      Timer.periodic(const Duration(milliseconds: 25), (timer) {
-        if (_navigatorKey.currentState != null && ref.read(isarProvider).hasValue) {
-          final showTimetable = ref.readPref(PrefKey.showTimetableMenu);
-          final paths = [
-            "home",
-            "digestive",
-            if (showTimetable) "timetable",
-            "more",
-          ];
-          final index = paths.indexOf(event.path);
-          if (index != -1) {
-            _onBottomNavTap(index, event.path);
-          } else {
-            showSnackBar(context, "この機能は無効化されています。カスタマイズ設定から有効化してください。");
-          }
-          timer.cancel();
-        }
-      });
-    });
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(dataSyncServiceProvider.notifier).fetchData();
     });
@@ -159,11 +137,37 @@ class HomePageState extends ConsumerState<HomePage> {
   @override
   void dispose() {
     bannerAd?.dispose();
-    switchBottomNavListener?.cancel();
     for (final controller in _scrollControllers.values) {
       controller.dispose();
     }
     super.dispose();
+  }
+
+  /// Handles a deep-link tab-switch request.
+  ///
+  /// Polls until the navigator is mounted and Isar has loaded before switching
+  /// the bottom navigation, preserving the readiness timing of the former
+  /// event-driven flow.
+  void _handleTabSwitchRequest(TabSwitchRequest request) {
+    Timer.periodic(const Duration(milliseconds: 25), (timer) {
+      if (_navigatorKey.currentState != null &&
+          ref.read(isarProvider).hasValue) {
+        final showTimetable = ref.readPref(PrefKey.showTimetableMenu);
+        final paths = [
+          "home",
+          "digestive",
+          if (showTimetable) "timetable",
+          "more",
+        ];
+        final index = paths.indexOf(request.path);
+        if (index != -1) {
+          _onBottomNavTap(index, request.path);
+        } else {
+          showSnackBar(context, "この機能は無効化されています。カスタマイズ設定から有効化してください。");
+        }
+        timer.cancel();
+      }
+    });
   }
 
   @override
@@ -175,6 +179,12 @@ class HomePageState extends ConsumerState<HomePage> {
     ref.listen(dataSyncServiceProvider, (_, next) {
       if (next is AsyncError) {
         _handleSyncError(next.error, next.stackTrace);
+      }
+    });
+
+    ref.listen(tabSwitchProvider, (_, next) {
+      if (next case AsyncData(:final value)) {
+        _handleTabSwitchRequest(value);
       }
     });
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -369,14 +369,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  event_bus:
-    dependency: "direct main"
-    description:
-      name: event_bus
-      sha256: "1a55e97923769c286d295240048fc180e7b0768902c3c2e869fe059aafa15304"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   extension_google_sign_in_as_googleapis_auth:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   cupertino_icons: ^1.0.6
   audioplayers: ^6.0.0
   animations: ^2.1.1
-  event_bus: ^2.0.0
   package_info_plus: ^8.3.1
   flutter_svg: ^2.2.4
   shared_preferences: ^2.5.4


### PR DESCRIPTION
## T11 — Remove EventBus, replace with Riverpod

Replaces the global `event_bus` singleton with a Riverpod construct for the deep-link → bottom-nav tab-switch flow.

### What changed
- **New** `lib/infrastructure/tab_switch_provider.dart`: a `@Riverpod(keepAlive: true)` `TabSwitch` notifier backed by a broadcast `StreamController`, exposing a stream of `TabSwitchRequest(path)` and a `fire(path)` method. This is a domain-independent cross-cutting navigation concern, so it lives in `infrastructure/`.
- **`lib/main.dart`**: the deep-link handler now fires via `ref.read(tabSwitchProvider.notifier).fire(tabName)` instead of `eventBus.fire(SwitchBottomNav(tabName))`. Removed the `events.dart` import.
- **`lib/pages/home_page.dart`**: consumes the stream via `ref.listen(tabSwitchProvider, ...)` in `build()` (alongside the existing `dataSyncServiceProvider` listener), delegating to a new `_handleTabSwitchRequest` method that runs the **same** `Timer.periodic(25ms)` readiness poll (waits for navigator mount AND `isarProvider` value) before switching, and shows the same disabled-feature snackbar for unknown paths. Removed the manual `StreamSubscription` field and its `dispose()` cancel — no longer needed.
- **Deleted** `lib/events.dart`; **removed** `event_bus` from `pubspec.yaml`.
- Translated the touched Japanese comments to English; the user-facing Japanese snackbar string is unchanged.

### Behavior preservation
No functional change. The tab switch still waits for the navigator to mount and Isar to load before switching, and still shows `この機能は無効化されています。カスタマイズ設定から有効化してください。` for disabled/unknown paths.

### Definition of Done
- `grep -rn "eventBus\|EventBus\|events.dart" lib/` → **0 hits**
- `fvm dart run build_runner build --delete-conflicting-outputs` run; generated `tab_switch_provider.g.dart` committed.
- `fvm flutter analyze` clean — no new errors/warnings (336 issues vs 338 on base; all remaining are pre-existing and unrelated to touched files).
- `fvm flutter test` — all 120 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjcn2suf8gKU1YoiyThKYJ)_